### PR TITLE
Script improvements and bug fixes

### DIFF
--- a/script/module_library_setup.R
+++ b/script/module_library_setup.R
@@ -157,6 +157,9 @@ write_file_from_template <- function(source, destination) {
     ## suppressWarnings: not all "templates" have conversion specifiers
     processed_text <- suppressWarnings(sprintf(template_text, package_name))
 
+    ## ensure target directory exists
+    dir.create(dirname(destination), recursive = TRUE, showWarnings = FALSE)
+
     safe_writeLines(processed_text, destination)
 }
 
@@ -171,23 +174,21 @@ process_row <- function(row) {
 
 package_name <- get_package_name()
 
-## ensure target directories exist
-tests_directory <- file.path('..', 'tests')
-test_data_directory <- file.path('..', 'tests', 'module_test_cases')
-testthat_directory <- file.path('..', 'tests', 'testthat')
-module_library_directory <- file.path('..', 'src', 'module_library')
-for (dir in c(tests_directory, test_data_directory,
-              testthat_directory, module_library_directory)) {
-    invisible(dir.exists(dir) || dir.create(dir))
-}
-
 file_set <- read.csv(file.path('templates', 'template_table'), sep = '')
 
 invisible(apply(file_set, 1, process_row))
 
+
+## Since the example test data file is named dynamically, it isn't
+## included in file_set and is handled separately:
+
+test_data_directory <- file.path('..', 'tests', 'module_test_cases')
 test_data_destination <- file.path(test_data_directory,
                                    paste0(package_name,
                                           '_example_module.csv'))
+
+## ensure the target directory exists
+dir.create(test_data_directory, recursive = TRUE, showWarnings = FALSE)
 
 invisible(write_file_from_template(
     source = file.path('templates', 'module_test_cases.csv'),

--- a/script/module_library_setup.R
+++ b/script/module_library_setup.R
@@ -72,12 +72,12 @@ validate_package_name <- function(runtime_params) {
                     ",
                     x = package_name)
         if (!ok) {
-            cat(package_name,
-                " is not a valid package name.\n",
+            cat("\n", package_name, " is not a valid package name.\n\n",
                 "To be a valid package name, a name must\n",
                 "* Start with a letter\n",
                 "* Contain only ASCII letters and numbers\n\n",
-                "Try again (return to exit): ")
+                "Try again (return to exit): ",
+                sep = "")
             package_name <- smartReadLines()
             if (package_name == '') stop_quietly()
         } else {
@@ -95,8 +95,8 @@ run_addl_checks <- function(package_name) {
     if (nchar(package_name) > name_length_limit)
     {
         cat("\nIt is recommended that package names not exceed ",
-            sprintf("%i characters, ", name_length_limit),
-            "since this will cause a path name length error when running ",
+            sprintf("%i characters,\n", name_length_limit),
+            "since this will cause a path name length error when running\n",
             "`R CMD check` and/or submitting the package to CRAN.\n\n",
             "Enter a new name, or '-f' to ignore this recommendation: ",
             sep = "")
@@ -132,6 +132,23 @@ get_package_name <- function() {
     package_name
 }
 
+safe_writeLines <- function(text, destination) {
+    if (file.exists(destination)) {
+        if (all(readLines(destination) == text)) {
+            message(sprintf("No changes to %s.", destination))
+            return()
+        } else {
+            backup_file_name <- tempfile(tmpdir = dirname(destination),
+                                         pattern = paste0(basename(destination), '-'),
+                                         fileext = ".bak")
+            message(sprintf("moving %s to %s", destination, backup_file_name))
+            file.rename(destination, backup_file_name)
+        }
+    }
+    writeLines(text, destination)
+    message(sprintf("wrote %s", destination))
+}
+
 write_file_from_template <- function(source, destination) {
     file <- file(source)
     template_text <- readLines(file)
@@ -140,8 +157,7 @@ write_file_from_template <- function(source, destination) {
     ## suppressWarnings: not all "templates" have conversion specifiers
     processed_text <- suppressWarnings(sprintf(template_text, package_name))
 
-    writeLines(processed_text, destination)
-    message(sprintf("wrote %s", destination))
+    safe_writeLines(processed_text, destination)
 }
 
 process_row <- function(row) {
@@ -155,19 +171,24 @@ process_row <- function(row) {
 
 package_name <- get_package_name()
 
+## ensure target directories exist
+tests_directory <- file.path('..', 'tests')
+test_data_directory <- file.path('..', 'tests', 'module_test_cases')
+testthat_directory <- file.path('..', 'tests', 'testthat')
+module_library_directory <- file.path('..', 'src', 'module_library')
+for (dir in c(tests_directory, test_data_directory,
+              testthat_directory, module_library_directory)) {
+    invisible(dir.exists(dir) || dir.create(dir))
+}
+
 file_set <- read.csv(file.path('templates', 'template_table'), sep = '')
 
 invisible(apply(file_set, 1, process_row))
-
-test_data_directory <- file.path('..', 'tests', 'module_test_cases')
-
-invisible(dir.exists(test_data_directory) ||
-          dir.create(test_data_directory))
 
 test_data_destination <- file.path(test_data_directory,
                                    paste0(package_name,
                                           '_example_module.csv'))
 
-write_file_from_template(source = file.path('templates',
-                                            'module_test_cases.csv'),
-                         test_data_destination)
+invisible(write_file_from_template(
+    source = file.path('templates', 'module_test_cases.csv'),
+    test_data_destination))


### PR DESCRIPTION
The most important change of this PR is to ensure that needed directories exist before attempting to write to them.  This includes
* tests
* tests/module_test_cases
* tests/testthat
* src/module_library

which don't currently exist in the repository on the `reduce-potential-merge-conflicts` branch.  (It is not clear how this will all shake out in the end after the `shorten-boost-directory` branch is merged.  This change may prove unnecessary after all.)

The other significant change is in response to the concern about overwriting user's files mentioned in [this comment](https://github.com/biocro/skelBML/pull/1#issuecomment-1325589932).  This version of the script backs up existing files that the script would change.  

(Another option would simply be to refuse to run, telling the user to delete or rename files that would otherwise be overwritten and then to try again.

Not unexpectedly trashing a user's work seems like the _polite_ way for a script to operate.  It's one thing to overwrite files when one is, say, upgrading some software, but it's quite another to overwrite, without warning, files in a user's workspace.

As an aside, one of the reasons I have been leery about using devtools is that certain commands may delete or alter the user's package files without warning.  See, for example, [this comment](https://community.rstudio.com/t/rstudio-deletes-inst-doc-when-checking-or-building-a-package/25926).  (This behavior may have changed since then.  Now, I think the user is prompted for permission before files are deleted, at least in this case.)  While some users presumably always use a VCS and always check in any significant changes before turning to other work, I, for one, don't necessarily work this way.)

A third change is simply better formatting of user prompts.