### PR TITLE
Replace links to `ebimodeling`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,12 +85,11 @@ using the following functions from the `usethis` R package:
   that describes a data set or a long-form vignette, it might be helpful to use
   `pkgdown` to build an automatically-updated website for your package. This
   will make your documentation more accessible to current or potential users.
-  For an example, see the
-  [BioCro pkgdown website](https://ebimodeling.github.io/biocro-documentation/docs/index.html).
-  A `pkgdown` website workflow can be initialized by calling
-  `usethis::use_pkgdown_github_pages()` from an R session running in the main
-  directory of your package repository. This would be most useful for a public
-  module library repository.
+  For an example, see the [public BioCro Documentation
+  website](https://biocro.github.io). A `pkgdown` website workflow can be
+  initialized by calling `usethis::use_pkgdown_github_pages()` from an R session
+  running in the main directory of your package repository. This would be most
+  useful for a public module library repository.
 - If you want to make sure that your package tests pass on multiple operating
   systems, it might be helpful to automatically run `R CMD check` on development
   branches before merging them into your main branch. Such a workflow can be
@@ -160,16 +159,15 @@ branch.
 
 ### Making contributions
 
-Please see the
-[contribution guidelines](https://github.com/ebimodeling/biocro/blob/main/developer_documentation/contribution_guidelines.md)
-before submitting changes.
+Please see the contribution guidelines before submitting changes.
+These may be found in Chapter One of the _Developer's Manual_ on the
+[public BioCro Documentation web site](https://biocro.github.io).
 
 ### Software Documentation
 
-See the
-[BioCro Documentation website](https://ebimodeling.github.io/biocro-documentation/),
-which includes documentation for the C++ framework, the BioCro R package, and
-the standard module library.
+See the [public BioCro Documentation web
+site](https://biocro.github.io), which includes documentation for the C++
+framework, the BioCro R package, and the standard module library.
 
 ### License
 

--- a/script/templates/README.md
+++ b/script/templates/README.md
@@ -54,7 +54,7 @@ module_info('%1$s:example_module')
 evaluate_module('%1$s:example_module', list(A = 1, B = 2))
 ```
 For more information about using BioCro modules in R, please see the
-[BioCro framework R package](https://github.com/ebimodeling/biocro).
+[BioCro framework R package](https://github.com/biocro/biocro).
 
 ### Source
 

--- a/script/templates/module_library.Rd
+++ b/script/templates/module_library.Rd
@@ -12,7 +12,7 @@
   essential functions required to interact with the modules in this library. For
   more information, see \code{\link[BioCro]{modules}},
   \code{\link[BioCro]{run_biocro}}, and the BioCro framework R package
-  \href{https://github.com/ebimodeling/biocro}{repository}.
+  \href{https://github.com/biocro/biocro}{repository}.
 }
 
 \details{

--- a/script/templates/skeleton_version.h
+++ b/script/templates/skeleton_version.h
@@ -8,7 +8,7 @@
 
 namespace %1$s
 {
-static const std::string skeleton_version = "2.1.0";
+static const std::string skeleton_version = "2.1.1";
 }
 
 #endif

--- a/skelBML_description
+++ b/skelBML_description
@@ -1,7 +1,7 @@
 ## WARNING: This file was included in this package by the BioCro skeleton module
 ## library and should not be manually edited.
 
-skelBML version 2.1.0 (https://github.com/biocro/skelBML)
+skelBML version 2.1.1 (https://github.com/biocro/skelBML)
 
 Created by Justin M. McGrath, Edward B. Lochocki, and Scott Rohde.
 
@@ -10,7 +10,7 @@ package. Running the setup script on a copy of this repository will create a
 basic BioCro module library R package with a single example module. Then,
 additional modules can be added. See `docs/README.md` for detailed instructions
 explaining how to do this. For more information about BioCro and BioCro module
-libraries, see the BioCro R package (https://github.com/ebimodeling/biocro) and
+libraries, see the BioCro R package (https://github.com/biocro/biocro) and
 Lochocki et al. (2022) (https://doi.org/10.1093/insilicoplants/diac003).
 
 skelBML contains independent works with different licenses. Excluding the

--- a/skelBML_news.md
+++ b/skelBML_news.md
@@ -20,6 +20,7 @@ for the next release.
 
 - Updated some links in the package documentation to point to the new stable
   BioCro R package repository location
+- The C++ framework has been updated to v1.1.1
 - Any module libraries that were based on earlier versions of `skelBML` should
   run `script/module_library_setup.R` when updating to version 2.1.1 to help
   remove any outdated links in their own documentation.

--- a/skelBML_news.md
+++ b/skelBML_news.md
@@ -16,6 +16,11 @@ Subsequent commits will then include a new "UNRELEASED" section in preparation
 for the next release.
 -->
 
+# skelBML VERSION 2.1.1
+
+- Updated some links in the package documentation to point to the new stable
+  BioCro R package repository location
+
 # skelBML VERSION 2.1.0 (2023-06-15)
 
 - This version uses the latest BioCro C++ framework and adds two new unexported

--- a/skelBML_news.md
+++ b/skelBML_news.md
@@ -20,6 +20,9 @@ for the next release.
 
 - Updated some links in the package documentation to point to the new stable
   BioCro R package repository location
+- Any module libraries that were based on earlier versions of `skelBML` should
+  run `script/module_library_setup.R` when updating to version 2.1.1 to help
+  remove any outdated links in their own documentation.
 
 # skelBML VERSION 2.1.0 (2023-06-15)
 


### PR DESCRIPTION
I set up the `skelBML` repository to use `git-flow`. This is a simple PR to update some old links that pointed to the `ebimodeling` GitHub organization.

I will hold off on merging this for now until the `framework` code has also been updated. Then I can update the git submodule here and fully remove all mentions of `ebimodeling`.

Update: I just brought in the new version of the framework, so this is ready for review.