### PR TITLE
Update framework and skelBML version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -133,9 +133,7 @@ the following steps:
    git merge upstream/main
    ```
    You may need to address one or more merge conflicts at this point.
-4. Check `NEWS_skeleton.md` to see if the new version of the skeleton module
-   library requires you to rerun the setup script; if it does, then take the
-   following steps:
+4. Complete the update as follows:
    1. Rerun the setup script, running it as described above.
    2. Any files that would be changed by the script will be backed up; for
       example, if the script would modify

--- a/script/templates/skeleton_version.h
+++ b/script/templates/skeleton_version.h
@@ -8,7 +8,7 @@
 
 namespace %1$s
 {
-static const std::string skeleton_version = "2.1.1";
+static const std::string skeleton_version = "2.1.2";
 }
 
 #endif

--- a/skelBML_description
+++ b/skelBML_description
@@ -1,7 +1,7 @@
 ## WARNING: This file was included in this package by the BioCro skeleton module
 ## library and should not be manually edited.
 
-skelBML version 2.1.1 (https://github.com/biocro/skelBML)
+skelBML version 2.1.2 (https://github.com/biocro/skelBML)
 
 Created by Justin M. McGrath, Edward B. Lochocki, and Scott Rohde.
 

--- a/skelBML_news.md
+++ b/skelBML_news.md
@@ -16,6 +16,10 @@ Subsequent commits will then include a new "UNRELEASED" section in preparation
 for the next release.
 -->
 
+# skelBML VERSION 2.1.2
+
+- The C++ framework has been updated to v1.1.3
+
 # skelBML VERSION 2.1.1
 
 - Updated some links in the package documentation to point to the new stable


### PR DESCRIPTION
Updated C++ framework to version 1.1.3.

Also changed instructions for updating from a new version of `skelBML`, since the startup script should always be rerun.